### PR TITLE
Completed positional localisation

### DIFF
--- a/Assignment1/src/net/robotics/main/Localisation.java
+++ b/Assignment1/src/net/robotics/main/Localisation.java
@@ -3,6 +3,10 @@ package net.robotics.main;
 
 import net.robotics.map.Map;
 import net.robotics.map.Tile;
+import net.robotics.sensor.ColorSensorMonitor.ColorNames;
+import lejos.hardware.sensor.EV3ColorSensor;
+import net.robotics.sensor.ColorSensorMonitor;
+import net.robotics.sensor.ColorSensorMonitor.ColorNames;
 import lejos.robotics.navigation.Pose;
 import lejos.hardware.Button;
 import lejos.hardware.lcd.Font;
@@ -27,6 +31,11 @@ public class Localisation {
 	// Need to add "Position confidence"
 	// Need to add "Orient confidence"
 	
+	private float oriConfidence; 	//Orientation confidence. 
+	private float posiConfidence;	//Position confidence.
+	
+	
+	
 	public enum dHeadingPosition {
 		Top, Right, Down, Left
 	}
@@ -37,6 +46,11 @@ public class Localisation {
 			{0,-1},// Below 	[2]
 			{-1,0},// To left	[3]
 	};
+	
+	public Localisation() {
+		oriConfidence = 1.0f;
+		posiConfidence = 1.0f;
+	}
 	
 	public void localisePosition() {
 		int initialHeading = Robot.current.getMap().getRobotHeading();
@@ -49,44 +63,108 @@ public class Localisation {
 		}
 		
 		// Localisation method depends upon number of edges
+		// If edges are opposite one another, we can only localise w.r.t. one axis
+		// So we localise using 1 edge instead, and one space. 
 		switch(nFoundEdges) {
 			case 3:
-			case 2:
-				localisePosition2Edges(foundEdges, nFoundEdges);	// If 2 or 3 edges, localise against 2 edges
+				localise2Edges(foundEdges);
 				break;
+			case 2: 
+				if ((foundEdges[1]==true && foundEdges[3]==true) || (foundEdges[0]==true && foundEdges[2]==true)) {
+					localise1Edge(foundEdges);
+					break;
+				} else {
+					localise2Edges(foundEdges);
+					break;
+				}
 			case 1:
-				localisePosition1Edge(foundEdges);	// If 1 edge, localise against 1 edge, one space
+				localise1Edge(foundEdges);
 				break;
 			case 0:
-				localisePositionNoEdges(foundEdges);// If 0 edges, localise against 2 spaces
+				localise0Edge(foundEdges);
 				break;
 		}
 	}
 	
-	public void localisePosition2Edges(boolean[] foundEdges, int nFoundEdges) {
-		int initialHeading = Robot.current.getMap().getRobotHeading();
-		int xLocaliseCell;
-		int yLocaliseCell;
-		
-		// If there are 2 edges and they are opposite each other, use the 1 edge method
-		if( nFoundEdges == 2 && ((foundEdges[1]==true && foundEdges[3]==true) || (foundEdges[0]==true && foundEdges[2]==true)) ) {
-			localisePosition1Edge(foundEdges);
-		} else {
-			if(foundEdges[0] == true) {
-				yLocaliseCell = 0;
+		// If 2 or more perpendicular edges, use this method
+		// Localises X position, Y position, and orientation
+		// Localises using 2 edges
+		public void localise2Edges(boolean[] foundEdges) {
+			int initialHeading = Robot.current.getMap().getRobotHeading();
+			int xLocaliseCell;
+			int yLocaliseCell;
+			
+			if(foundEdges[0] == true) {		// We know the edges are perpendicular, and we have at least 2
+				yLocaliseCell = 0;			// So if it's not one, it is the other
 			} else yLocaliseCell = 2;
 			
 			if(foundEdges[1] == true) {
 				xLocaliseCell = 1;
 			} else xLocaliseCell = 3;
 			
-			Robot.current.turnToHeading(yLocaliseCell);
-			alignWithEdge();
-			Robot.current.turnToHeading(xLocaliseCell);
-			alignWithEdge();
-			Robot.current.turnToHeading(initialHeading);
+			Robot.current.turnToHeading(yLocaliseCell);		// Turn to y cell
+			alignWithEdge();								// y position now localised
+			Robot.current.turnToHeading(xLocaliseCell);		// turn to x cell
+			alignWithEdge();								// x position now localised
+			Robot.current.turnToHeading(initialHeading);	// return to initial pose
+			
+			posiConfidence = 1.0f;			// 100% confidence of position
 		}
-	}
+		
+		
+		
+		// If 1 edge or 2 opposite edges, use this method
+		// Localises X position, Y position, and orientation
+		// Localises using 1 edge, and 1 space
+		public void localise1Edge(boolean[] foundEdges) {
+			int initialHeading = Robot.current.getMap().getRobotHeading();
+			int xLocaliseCell;
+			int yLocaliseCell;
+			
+			for (int i=0; i<4; i++) {
+				 if(foundEdges[i]) {									// If edge is present,
+					 if (i == 0 || i == 2) {							// and if edge is top or bottom
+						 yLocaliseCell = i;								// Set yLocalise cell to it
+						 xLocaliseCell = 1;								// Set xLocalise as left or right (both empty)
+						 Robot.current.turnToHeading(yLocaliseCell);	// Turn to yLocalise cell and 
+						 alignWithEdge();								// Align to edge and localise y position
+						 Robot.current.turnToHeading(xLocaliseCell);	// Turn to xLocalise cell and
+						 alignGridLine();								// Align to grid line and localise x position
+						 Robot.current.turnToHeading(initialHeading);
+						 break;
+					 } else {											// Otherwise edge is left or right
+						 xLocaliseCell = i;								// Set xLocalise cell to it
+						 yLocaliseCell = 0;								// Set yLocalise as top or bottom (both empty)
+						 Robot.current.turnToHeading(xLocaliseCell);	// turn to xLocalise cell and
+						 alignWithEdge();								// Align to edge and localise x position
+						 Robot.current.turnToHeading(yLocaliseCell);	// Turn to yLocalise cell
+						 alignGridLine();								// Align to grid line and localise y position
+						 Robot.current.turnToHeading(initialHeading);
+						 break;
+					 }
+				 }
+			}
+			posiConfidence = 1.0f;
+		}
+		
+		
+		
+		// If no edges, use this method
+		// Localises X position and Y position
+		// Localises using 2 spaces
+		public void localise0Edge(boolean[] foundEdges) {
+			int initialHeading = Robot.current.getMap().getRobotHeading();
+			
+			Robot.current.turnToHeading(0);					// Turn to yLocalise cell and 
+			alignGridLine();								// Align to grid and localise y position
+			Robot.current.turnToHeading(1);					// Turn to xLocalise cell and
+			alignGridLine();								// Align to grid line and localise x position
+			Robot.current.turnToHeading(initialHeading);
+			
+			posiConfidence = 1.0f;
+		}
+
+		
 	
 	public void localisePosition1Edge(boolean[] foundEdges) {
 		int initialHeading = Robot.current.getMap().getRobotHeading();
@@ -188,22 +266,10 @@ public class Localisation {
 		SampleProvider leftTouch = Robot.current.getLeftTouch();
 		SampleProvider rightTouch = Robot.current.getRightTouch();
 		
-		
-		
 		pilot.forward();
 		while((leftSample[0] < 0.9 || rightSample[0] < 0.9)) {
 			leftTouch.fetchSample(leftSample, 0);
 	    	rightTouch.fetchSample(rightSample, 0);
-	    	
-	    	Robot.current.screen.clearScreen();
-	    	Robot.current.screen.writeTo(new String[]{
-					"H: " + leftSample[0],
-					"0: " + rightSample[0],
-			}, 0, 60, GraphicsLCD.LEFT, Font.getSmallFont());
-	    	
-	    	if(Button.ESCAPE.isDown()){
-	    		System.exit(0);
-	    	}
 		}
 		pilot.stop();
 		
@@ -213,6 +279,17 @@ public class Localisation {
 		}, 0, 60, GraphicsLCD.LEFT, Font.getSmallFont());
 		
 		pilot.travel(-4);
+		oriConfidence = 1.0f;
+	}
+	
+	public void alignGridLine() {
+		MovePilot pilot = Robot.current.getPilot();
+		ColorNames cn;
+		pilot.forward();
+		do{
+			cn = Robot.current.getColorSensor().getCurrentColor();
+		}while(cn != ColorNames.BLACK);
+		pilot.travel(-11.0f);
 	}
 	
 	public boolean getEdgePresent() {
@@ -223,5 +300,18 @@ public class Localisation {
 			return false;
 		}
 	}
+	
+	public float getOriConfidence() {
+		return oriConfidence;
+	}
+	
+	public void setOriConfidence(float oriConfidence) {
+		this.oriConfidence = oriConfidence;
+	}
+	
+	public float getPosiConfidence() {
+		return posiConfidence;
+	}
+	
 
 }

--- a/Assignment1/src/net/robotics/main/Robot.java
+++ b/Assignment1/src/net/robotics/main/Robot.java
@@ -49,6 +49,7 @@ public class Robot {
 	private MovePilot pilot;
 	private OdometryPoseProvider opp;
 	private Map map;
+	private Localisation localisation;
 	
 	public final float _OCCUPIEDBELIEFCUTOFF = 0.75f;
 	
@@ -66,7 +67,7 @@ public class Robot {
 	
 	public static Robot current;
 	
-	
+
 
 	public static void main(String[] args){
 		current = new Robot();
@@ -85,6 +86,8 @@ public class Robot {
 
 		colorSensor = new ColorSensorMonitor(this, new EV3ColorSensor(myEV3.getPort("S2")), 16);
 		
+		localisation = new Localisation();
+		
 		NXTRegulatedMotor motor = null;
 		EV3UltrasonicSensor ultra = null;
 		
@@ -96,7 +99,6 @@ public class Robot {
 			} catch(Exception e) {
 			}
 		}
-		
 		
 		ultrasonicSensor = new UltrasonicSensorMonitor(this, 
 				ultra, 
@@ -112,8 +114,6 @@ public class Robot {
 		colorSensor.start();
 		
 		ultrasonicSensor.start();
-
-
 	}
 
 	private void setUpRobot(){
@@ -122,9 +122,6 @@ public class Robot {
 		// Create a pose provider and link it to the move pilot
 		opp = new OdometryPoseProvider(pilot);
 	}
-	
-	
-	
 
 	public void closeProgram(){
 		closeRobot();
@@ -149,8 +146,6 @@ public class Robot {
 		screen.drawMap(screen.getWidth()-8-map.getWidth()*16, -4, map);*/
 		
 		//Button.waitForAnyPress();
-		
-		Localisation localisation = new Localisation();
 		
 		map.setRobotPos(3, 4, 3);
 		map.getTile(3, 5).view(false);
@@ -383,5 +378,9 @@ public class Robot {
 	
 	public SampleProvider getRightTouch() {
 		return rightTouch;
+	}
+	
+	public ColorSensorMonitor getColorSensor() {
+		return colorSensor;
 	}
 }


### PR DESCRIPTION
Robot is now (in theory) able to localise for both y position and x position. 

Localisation now has a switch case where it prioritises localising against edges. This is because localising against an edge localises for x or y, as well as orientation. 

Priorities for localisation are therefore:
- 2 or more perpendicular edges
- 2 opposite edges, or 1 edge
- 0 edges

- 2 or more perpendicular edges localises to 2 edges  (and increases confidence of both orientation and position) 
- 2 opposite edges or 1 edge localises on 1 edge and one space (and increases confidence of both orientation and position) 
- 0 edges localises on two spaces (and increases confidence of position alone)